### PR TITLE
Adjust RPATH handling for macOS in SConstruct

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -17,8 +17,15 @@ env.Append(
     CPPPATH=["src/", "include/"],
     LIBPATH=["lib/"],
     LIBS=["discord_partner_sdk"],
-    RPATH=["."],
 )
+
+# MacOS seems to dislike the way this RPATH flag gets passed to the linker.
+# appending -rpath as LINKFLAGS seem to work - using @loader_path to point 
+#to the library's own path.
+if env["platform"] == "macos":
+    env.Append(LINKFLAGS=["-Wl,-rpath,@loader_path"])
+elif env["platform"] == "linux":
+    env.Append(RPATH=["."])
 
 sources = Glob("src/*.cpp")
 


### PR DESCRIPTION
Was seeing macOS fail to build with the following error:
```
ld: unknown options: -rpath=.
clang++: error: linker command failed with exit code 1
```

SCons' RPATH construction variable generates -rpath=. when passed to the linker. Linux seems to accept this syntax while macOS does not (it expects -rpath <path> (without the =)). This plumbs the correct flag through `LINKFLAGS` in this case and uses `@loader_path` to refer to the current directory.

Once this change was made I was able to successfully build for Mac.